### PR TITLE
fix delete team endpoint with admin

### DIFF
--- a/src/routes/team.js
+++ b/src/routes/team.js
@@ -46,13 +46,14 @@ team.patch('/:team_id',
     checkExistingTeam,
     editTeam);
 
+team.delete('/:team_id',
+    verifyAdminRole,
+    verifyTeamWithId,
+    deleteTeam);
+
 team.get('/:team_id',
     verifyTeamWithId,
     getTeam);
-
-team.delete('/:team_id',
-    verifyTeamWithId,
-    deleteTeam);
 
 team.get('',
     getAllTeams);

--- a/src/tests/team/teamEndpoint.test.js
+++ b/src/tests/team/teamEndpoint.test.js
@@ -115,6 +115,34 @@ describe('Test team endpoints', () => {
         done();
     });
 
+    it('should return error if user tries to update a team', async (done) => {
+        const res = await request(app)
+            .patch(`/api/v1/teams/${team1Id}`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .set('Accept', 'application/json')
+            .send({
+                name: 'test team35',
+                code: 'tstr',
+                venue_name: 'real stadium',
+                venue_capacity: 2345
+            });
+
+        expect(res.status).toEqual(403);
+        expect(res.body.message).toBe('permission denied');
+        done();
+    });
+
+    it('should return error if user tries to update a team', async (done) => {
+        const res = await request(app)
+            .delete(`/api/v1/teams/${team1Id}`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .set('Accept', 'application/json');
+
+        expect(res.status).toEqual(403);
+        expect(res.body.message).toBe('permission denied');
+        done();
+    });
+
 
     it('should return error if inputs are empty', async (done) => {
         const res = await request(app)


### PR DESCRIPTION
#### What does this PR do?
- Enable only admin to delete team

#### Description of Task to be completed?
- add middleware to verify admin role in delete team endpoint

#### Any background context you want to provide?
